### PR TITLE
fix: release workflow must checkout tag in build job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+      with:
+        ref: ${{ needs.validate.outputs.tag }}
 
     - name: Set up Python
       uses: actions/setup-python@v6


### PR DESCRIPTION
## Problem

The v2.3.0 release failed to publish to PyPI because the build job was checking out the main branch instead of the release tag.

## Solution

Added `ref: ${{ needs.validate.outputs.tag }}` to the build job's checkout step, ensuring it checks out the same tag as the validate job.

## Additional Context

v2.3.0 tag was created during the Python version migration and contains incompatible pyproject.toml (`>=3.12,<3.14`). This fix enables v2.3.1 to build and publish successfully.

## Checklist
- [x] Fix applied to release.yml
- [x] All workflows passing
- [x] Ready for v2.3.1 release